### PR TITLE
- Implemented relative move.

### DIFF
--- a/doc/vinarise.txt
+++ b/doc/vinarise.txt
@@ -149,6 +149,12 @@ VINARISE BUFFER KEY MAPPINGS 			*vinarise-buffer-key-mappings*
 		Move to input address. Hexadecimal and decimal are supported.
 		Note: If you input like "50%", move to 50% of filesize.
 
+<Plug>(vinarise_move_by_input_offset)		*<Plug>(vinarise_move_by_input_offset)*
+		Move by input offset relative to current position.
+		Hexadecimal and decimal are supported.
+		Note: If you input like "50%", move by 50% of filesize
+		      relative to current position.
+
 <Plug>(vinarise_move_to_first_address)		*<Plug>(vinarise_move_to_first_address)*
 		Move to first address in the binary file.
 
@@ -200,6 +206,7 @@ k			<Plug>(vinarise_prev_line)
 <C-g>			<Plug>(vinarise_print_current_position)
 r			<Plug>(vinarise_change_current_address)
 G			<Plug>(vinarise_move_to_input_address)
+go			<Plug>(vinarise_move_by_input_offset)
 gg			<Plug>(vinarise_move_to_first_address)
 gG			<Plug>(vinarise_move_to_last_address)
 /			<Plug>(vinarise_search_binary)


### PR DESCRIPTION
I implemented the feature to move the cursor relative to the current position.

The implementation is placed in autoload/vinarise/mappings.vim#s:move_by_input_offset function.
It is mapped to the keymapping "go &lt;Plug&gt;(vinarise_move_by_input_offset)."

The specification is as follows:
Running the command, Vim waits for a user to enter a moving offset.
This value must be a hexadecimal number(e.g. 0x19, -0x69), or a percentage of a file size(e.g. 19%, -69%).
When it is a negative number, the cursor moves by the absolute value to upper address direction, and vice versa.

The internal behavior is as follows:
1. Wait for a user to entering a moving offset.
2. Calculate the absolute address from the input.
3. Clamp the address to a range [0, file size - 1].
4. Call s:move_to_input_address function with the address.
