### PR TITLE
Fix line number printed bug in bitmapview

### DIFF
--- a/autoload/vinarise/plugins/bitmapview.vim
+++ b/autoload/vinarise/plugins/bitmapview.vim
@@ -85,6 +85,7 @@ function! s:bitmapview_open() "{{{
   setlocal nofoldenable
   setlocal hidden
   setlocal foldcolumn=0
+  setlocal nonumber
 
   " Autocommands.
   augroup plugin-vinarise


### PR DESCRIPTION
When set number enabled, the line number appears in bitmapview. So, I added `setlocal nonumber` in bitmapview.vim in oder to fix this problem.


![vinarise](https://cloud.githubusercontent.com/assets/2971112/7557807/d2533314-f7d2-11e4-82c4-98167aa19fc9.gif)
