### PR TITLE
Remove unused public function vinarise#util#escape_file_searching()

### DIFF
--- a/autoload/vinarise/util.vim
+++ b/autoload/vinarise/util.vim
@@ -77,9 +77,7 @@ endfunction
 function! vinarise#util#substitute_path_separator(...) abort
   return call(s:get_prelude().substitute_path_separator, a:000)
 endfunction
-function! vinarise#util#escape_file_searching(...) abort
-  return call(s:get_prelude().escape_file_searching, a:000)
-endfunction
+
 function! vinarise#util#iconv(...) abort
   return call(s:get_process().iconv, a:000)
 endfunction


### PR DESCRIPTION
* I suggested removing this function from vital.vim at https://github.com/vim-jp/vital.vim/pull/693
* The function does not seem to be used, nor documented, so it should be safe to remove.