### PR TITLE
Add the ability to use intel assembly syntax

### DIFF
--- a/autoload/vinarise/plugins/dump.vim
+++ b/autoload/vinarise/plugins/dump.vim
@@ -11,6 +11,12 @@ else
   let s:dump_BUFFER_NAME = '*vinarise-dump-objdump*'
 endif
 
+if g:vinarise_objdump_intel_assembly
+  let s:flags = ' -M intel-mnemonic -DCslx "'
+else
+  let s:flags = ' -DCslx "'
+endif
+
 " Variables 
 if !exists('g:vinarise_objdump_command')
   let g:vinarise_objdump_command = 'objdump'
@@ -52,7 +58,7 @@ function! s:dump_open() abort
   call s:initialize_dump_buffer()
 
   setlocal modifiable
-  execute 'silent %!'.g:vinarise_objdump_command.' -DCslx "'
+  execute 'silent %!'.g:vinarise_objdump_command.s:flags
         \ . vinarise.filename . '"'
   setlocal nomodifiable
   setlocal nomodified

--- a/doc/vinarise.txt
+++ b/doc/vinarise.txt
@@ -92,6 +92,12 @@ g:vinarise_objdump_command			*g:vinarise_objdump_command*
 		
 		Default: "objdump"
 
+g:vinarise_objdump_intel_assembly		*g:vinarise_enable_auto_detect*
+		If this variable is set to 1, then the assembly output from
+		objdump will use intel assembly syntax rather than at&t
+		assembly syntax.
+
+		Default: 0
 ------------------------------------------------------------------------------
 PLUGINS 					*vinarise-plugins*
 

--- a/plugin/vinarise.vim
+++ b/plugin/vinarise.vim
@@ -18,6 +18,8 @@ let g:vinarise_detect_large_file_size =
       \ get(g:, 'vinarise_detect_large_file_size', 10000000)
 let g:vinarise_cursor_ascii_highlight =
       \ get(g:, 'vinarise_cursor_ascii_highlight', 'Search')
+let g:vinarise_objdump_intel_assembly =
+      \ get(g:, 'vinarise_objdump_intel_assembly', 0)
 
 
 command! -nargs=* -bar -complete=customlist,vinarise#complete


### PR DESCRIPTION
I added the ability to use intel assembly syntax with your plugin, I know it's deprecated so not sure if you'd want to merge it in or not. If you do want to, and you see anything I missed in this PR let me know. I'd be happy to fix it :)  